### PR TITLE
Fix the compilation Error when kernel version is higher than v5.9.0

### DIFF
--- a/memguard.c
+++ b/memguard.c
@@ -1048,7 +1048,11 @@ static int throttle_thread(void *arg)
 		.sched_priority = MAX_USER_RT_PRIO/2,
 	};
 
+#if LINUX_VERSION_CODE > KERNEL_VERSION(5, 9, 0)
+	sched_set_fifo(current);
+#else
 	sched_setscheduler(current, SCHED_FIFO, &param);
+#endif
 
 	while (!kthread_should_stop() && cpu_online(cpunr)) {
 


### PR DESCRIPTION
When the kernel version is higher than v5.9.0, there is an Error
```
ERROR: modpost: "sched_setscheduler" [/home/fch/Desktop/memguard/memguard.ko] undefined!
make[2]: *** [scripts/Makefile.modpost:111：/home/fch/Desktop/memguard/Module.symvers] 错误 1
```

That is because, the function "sched_setscheduler" is not exported any more ( linux kernel version >= v5.9.0 ).
However, we can use another one.
```
void sched_set_fifo(struct task_struct *p)
{
	struct sched_param sp = { .sched_priority = MAX_RT_PRIO / 2 };
	WARN_ON_ONCE(sched_setscheduler_nocheck(p, SCHED_FIFO, &sp) != 0);
}
EXPORT_SYMBOL_GPL(sched_set_fifo);
```
